### PR TITLE
Update `bindgen` 0.59 => 0.68

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cty = "0.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = "0.59"
+bindgen = "0.68"
 glob = "0.3"
 
 [features]


### PR DESCRIPTION
This fixes a few errors with some derive implementations.

It may need further testing. I tested host and device on `rp2040`, and it worked.